### PR TITLE
Clean up unused AUTOGEN markers

### DIFF
--- a/abuseipdb_api.py
+++ b/abuseipdb_api.py
@@ -66,7 +66,3 @@ class AbuseIPDBProvider:
 
 # Module-level provider instance
 provider: IOCProvider = AbuseIPDBProvider()
-
-# --- AUTOGEN START
-# (Cursor will fill in)
-# --- AUTOGEN END 

--- a/greynoise_api.py
+++ b/greynoise_api.py
@@ -62,7 +62,3 @@ class GreyNoiseProvider:
 
 # Provide a module-level instance for convenient import elsewhere
 provider: IOCProvider = GreyNoiseProvider()
-
-# --- AUTOGEN START
-# (Cursor will fill in)
-# --- AUTOGEN END

--- a/otx_api.py
+++ b/otx_api.py
@@ -65,7 +65,4 @@ def get_provider():
 # Module-level provider instance
 provider: IOCProvider = get_provider()
 
-# --- AUTOGEN START
-# (Cursor will fill in)
-# --- AUTOGEN END 
 

--- a/provider_interface.py
+++ b/provider_interface.py
@@ -21,7 +21,3 @@ class IOCProvider(Protocol):
     TIMEOUT: ClassVar[int]  # seconds
 
     def query_ioc(self, ioc_type: str, ioc_value: str) -> IOCResult: ...
-
-# --- AUTOGEN START
-# (Cursor will fill in)
-# --- AUTOGEN END 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -25,7 +25,3 @@ def test_dummy_provider_is_instance():
     dummy = DummyProvider()
     assert isinstance(dummy, IOCProvider)
 
-
-# --- AUTOGEN START
-# (Cursor will fill in)
-# --- AUTOGEN END 

--- a/threatfox_api.py
+++ b/threatfox_api.py
@@ -58,7 +58,3 @@ class ThreatFoxProvider:
 
 # Module-level provider instance for easy registration
 provider: IOCProvider = ThreatFoxProvider()
-
-# --- AUTOGEN START
-# (Cursor will fill in)
-# --- AUTOGEN END 

--- a/virustotal_api.py
+++ b/virustotal_api.py
@@ -71,7 +71,3 @@ class VirusTotalProvider:
 def get_provider() -> VirusTotalProvider:  # noqa: D401
     """Return a fresh provider instance (simple factory)."""
     return VirusTotalProvider()
-
-# --- AUTOGEN START
-# (Cursor will fill in)
-# --- AUTOGEN END 


### PR DESCRIPTION
## Summary
- remove unused autogen placeholders from provider modules and interface
- tidy corresponding test file

## Testing
- `pytest -q` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685b9f271b04832181c9d23609f39ad2